### PR TITLE
Add workflow to update index for tmp-review

### DIFF
--- a/.github/scripts/generate_index.py
+++ b/.github/scripts/generate_index.py
@@ -1,0 +1,27 @@
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+TMP_REVIEW = ROOT / "_tmp-review"
+INDEX_FILES = [ROOT / "index.md", ROOT / "tmp-review/index.md"]
+
+header = """---
+title: 리류 모음
+layout: default
+---
+
+<ul>
+"""
+footer = "</ul>\n"
+
+items = []
+for path in sorted(TMP_REVIEW.rglob('*')):
+    if path.is_file():
+        rel = path.relative_to(TMP_REVIEW)
+        url = "{{ '/tmp-review/%s' | relative_url }}" % rel.as_posix()
+        items.append(f"  <li><a href=\"{url}\">{rel.name}</a></li>")
+
+content = header + "\n".join(items) + "\n" + footer
+
+for index in INDEX_FILES:
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_text(content, encoding='utf-8')

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,0 +1,24 @@
+name: Update Index
+
+on:
+  push:
+    paths:
+      - '_tmp-review/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Generate index
+        run: python .github/scripts/generate_index.py
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'Update index.md'
+          branch: ${{ github.ref }}

--- a/index.md
+++ b/index.md
@@ -4,7 +4,22 @@ layout: default
 ---
 
 <ul>
-  {% for doc in site.tmp-review %}
-    <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
-  {% endfor %}
+  <li><a href="{{ '/tmp-review/post1-2/ChatGPT Image 2025년 7월 28일 오후 02_13_15.png' | relative_url }}">ChatGPT Image 2025년 7월 28일 오후 02_13_15.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/c8d939b9-26fa-4641-b452-1f9df14874a0.png' | relative_url }}">c8d939b9-26fa-4641-b452-1f9df14874a0.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 185927.png' | relative_url }}">스크린샷 2025-07-27 185927.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 224948.png' | relative_url }}">스크린샷 2025-07-27 224948.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 225010.png' | relative_url }}">스크린샷 2025-07-27 225010.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 225029.png' | relative_url }}">스크린샷 2025-07-27 225029.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 233052.png' | relative_url }}">스크린샷 2025-07-27 233052.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 233939.png' | relative_url }}">스크린샷 2025-07-27 233939.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 234043.png' | relative_url }}">스크린샷 2025-07-27 234043.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 234119.png' | relative_url }}">스크린샷 2025-07-27 234119.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 105150.png' | relative_url }}">스크린샷 2025-07-28 105150.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 110801.png' | relative_url }}">스크린샷 2025-07-28 110801.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 125850.png' | relative_url }}">스크린샷 2025-07-28 125850.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 125951.png' | relative_url }}">스크린샷 2025-07-28 125951.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 130007.png' | relative_url }}">스크린샷 2025-07-28 130007.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 130019.png' | relative_url }}">스크린샷 2025-07-28 130019.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 131734.png' | relative_url }}">스크린샷 2025-07-28 131734.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 131749.png' | relative_url }}">스크린샷 2025-07-28 131749.png</a></li>
 </ul>

--- a/tmp-review/index.md
+++ b/tmp-review/index.md
@@ -4,7 +4,22 @@ layout: default
 ---
 
 <ul>
-  {% for doc in site.tmp-review %}
-    <li><a href="{{ doc.url }}">{{ doc.title }}</a></li>
-  {% endfor %}
+  <li><a href="{{ '/tmp-review/post1-2/ChatGPT Image 2025년 7월 28일 오후 02_13_15.png' | relative_url }}">ChatGPT Image 2025년 7월 28일 오후 02_13_15.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/c8d939b9-26fa-4641-b452-1f9df14874a0.png' | relative_url }}">c8d939b9-26fa-4641-b452-1f9df14874a0.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 185927.png' | relative_url }}">스크린샷 2025-07-27 185927.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 224948.png' | relative_url }}">스크린샷 2025-07-27 224948.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 225010.png' | relative_url }}">스크린샷 2025-07-27 225010.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 225029.png' | relative_url }}">스크린샷 2025-07-27 225029.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 233052.png' | relative_url }}">스크린샷 2025-07-27 233052.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 233939.png' | relative_url }}">스크린샷 2025-07-27 233939.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 234043.png' | relative_url }}">스크린샷 2025-07-27 234043.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-27 234119.png' | relative_url }}">스크린샷 2025-07-27 234119.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 105150.png' | relative_url }}">스크린샷 2025-07-28 105150.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 110801.png' | relative_url }}">스크린샷 2025-07-28 110801.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 125850.png' | relative_url }}">스크린샷 2025-07-28 125850.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 125951.png' | relative_url }}">스크린샷 2025-07-28 125951.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 130007.png' | relative_url }}">스크린샷 2025-07-28 130007.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 130019.png' | relative_url }}">스크린샷 2025-07-28 130019.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 131734.png' | relative_url }}">스크린샷 2025-07-28 131734.png</a></li>
+  <li><a href="{{ '/tmp-review/post1-2/스크린샷 2025-07-28 131749.png' | relative_url }}">스크린샷 2025-07-28 131749.png</a></li>
 </ul>


### PR DESCRIPTION
## Summary
- automate generating index of `_tmp-review` assets
- add workflow that regenerates index on every push to `_tmp-review`

## Testing
- `python .github/scripts/generate_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6887340a5f288330afa707b8757a4d0f